### PR TITLE
use constants instead of adjustable data for game asset data

### DIFF
--- a/game_gen_asset_data.py
+++ b/game_gen_asset_data.py
@@ -13,14 +13,14 @@ def gen(path: pth.Path):
 def gen_text(*, data: bytes, name: str, output: typ.TextIO):
     size = len(data)
     indent = " " * 11
-    output.write(f"{indent}78 {name}-asset-data-size value {size}.\n")
-    output.write(f"{indent}01 {name}-asset-data pic x({size}) value\n")
+    output.write(f"{indent}78 {name}-asset-data value\n")
     more_indent = indent + " " * 4
     chunk_size = (72 - len(more_indent) - 5) // 2
     for index in range(0, size, chunk_size):
         chunk = data[index : index + chunk_size].hex()
         follow = " &" if index + chunk_size < size else "."
         output.write(f'{more_indent}x"{chunk}"{follow}\n')
+    output.write(f"{indent}78 {name}-asset-data-size value length of {name}-asset-data.\n")
 
 
 def main():


### PR DESCRIPTION
letting the compiler specify the length "looks" clearer, but would yield the same result; it is possibly more useful to use `length of name-asset-data` in the code - or don't use that at all if it could be wrapped into a `CALL`able sub-program or user-defined function.

Warning: this is completely untested, just thought about that when viewing the video.